### PR TITLE
feat(protocol): ✨ added Minecraft 26.2 support

### DIFF
--- a/src/Minecraft/Commands/Brigadier/Registry/ArgumentSerializerMapping.cs
+++ b/src/Minecraft/Commands/Brigadier/Registry/ArgumentSerializerMapping.cs
@@ -58,6 +58,9 @@ public record ArgumentSerializerMapping(string Identifier, Dictionary<ProtocolVe
 
     public bool TryGetParserId(ProtocolVersion version, [MaybeNullWhen(false)] out int id)
     {
-        return VersionParserIdMapping.TryGetValue(version, out id);
+        if (!VersionParserIdMapping.TryGetValue(version, out id))
+            return false;
+
+        return id is not -1;
     }
 }

--- a/src/Minecraft/Network/Definitions/ArgumentParserDefinitions.cs
+++ b/src/Minecraft/Network/Definitions/ArgumentParserDefinitions.cs
@@ -183,6 +183,7 @@ public class ArgumentParserDefinitions
         ArgumentParserDefinition.From(new ArgumentSerializerMapping("minecraft:color",
             new()
             {
+                [ProtocolVersion.MINECRAFT_26_2] = -1,
                 [ProtocolVersion.MINECRAFT_1_19] = 16
             })),
         ArgumentParserDefinition.From(new ArgumentSerializerMapping("minecraft:component",
@@ -446,6 +447,11 @@ public class ArgumentParserDefinitions
             new()
             {
                 [ProtocolVersion.MINECRAFT_1_21_6] = 55
+            })),
+        ArgumentParserDefinition.From(new ArgumentSerializerMapping("minecraft:team_color",
+            new()
+            {
+                [ProtocolVersion.MINECRAFT_26_2] = 16
             }))
 
         #endregion

--- a/src/Minecraft/Network/Definitions/PacketIdDefinitions.cs
+++ b/src/Minecraft/Network/Definitions/PacketIdDefinitions.cs
@@ -317,7 +317,13 @@ public static class PacketIdDefinitions
         new(0x23, ProtocolVersion.MINECRAFT_1_19),
         new(0x25, ProtocolVersion.MINECRAFT_1_19_1),
         new(0x24, ProtocolVersion.MINECRAFT_1_19_3),
-        new(0x28, ProtocolVersion.MINECRAFT_1_19_4)
+        new(0x28, ProtocolVersion.MINECRAFT_1_19_4),
+        new(0x29, ProtocolVersion.MINECRAFT_1_20_2),
+        new(0x2B, ProtocolVersion.MINECRAFT_1_20_5),
+        new(0x2C, ProtocolVersion.MINECRAFT_1_21_2),
+        new(0x2B, ProtocolVersion.MINECRAFT_1_21_5),
+        new(0x30, ProtocolVersion.MINECRAFT_1_21_9),
+        new(0x31, ProtocolVersion.MINECRAFT_26_1)
     ];
 
     public static readonly MinecraftPacketIdMapping[] ClientboundRespawn =

--- a/src/Minecraft/Network/ProtocolVersion.cs
+++ b/src/Minecraft/Network/ProtocolVersion.cs
@@ -64,6 +64,7 @@ public class ProtocolVersion : IComparable
     public static readonly ProtocolVersion MINECRAFT_1_21_9 = new(773, "1.21.9", "1.21.10");
     public static readonly ProtocolVersion MINECRAFT_1_21_11 = new(774, "1.21.11");
     public static readonly ProtocolVersion MINECRAFT_26_1 = new(775, "26.1", "26.1.1", "26.1.2");
+    public static readonly ProtocolVersion MINECRAFT_26_2 = new(776, "26.2");
 
     public ProtocolVersion(int value, params ReleaseVersion[] names)
     {

--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Authentication/AuthenticationService.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Authentication/AuthenticationService.cs
@@ -5,6 +5,7 @@ using Void.Minecraft.Network;
 using Void.Minecraft.Network.Messages.Binary;
 using Void.Minecraft.Network.Messages.Packets;
 using Void.Minecraft.Players.Extensions;
+using Void.Minecraft.Profiles;
 using Void.Proxy.Api.Console;
 using Void.Proxy.Api.Events;
 using Void.Proxy.Api.Events.Authentication;
@@ -120,7 +121,12 @@ public class AuthenticationService(ILogger<AuthenticationService> logger, IEvent
         if (link.Player.Profile is not { } profile)
             throw new InvalidOperationException("Player should be logged in already");
 
-        await link.SendPacketAsync(new LoginSuccessPacket { GameProfile = profile, StrictErrorHandling = false }, cancellationToken);
+        await link.SendPacketAsync(new LoginSuccessPacket
+        {
+            GameProfile = profile,
+            StrictErrorHandling = false,
+            SessionId = link.Player.ProtocolVersion >= ProtocolVersion.MINECRAFT_26_2 ? Uuid.NewUuid() : null
+        }, cancellationToken);
 
         await link.ReceivePacketAsync<LoginAcknowledgedPacket>(cancellationToken);
     }

--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Clientbound/JoinGamePacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Clientbound/JoinGamePacket.cs
@@ -1,0 +1,167 @@
+﻿using Void.Minecraft.Buffers;
+using Void.Minecraft.Network;
+using Void.Minecraft.Network.Messages.Packets;
+using Void.Minecraft.World;
+
+namespace Void.Proxy.Plugins.ProtocolSupport.Java.v1_20_2_to_latest.Packets.Clientbound;
+
+public class JoinGamePacket : IMinecraftClientboundPacket<JoinGamePacket>
+{
+    public required int EntityId { get; set; }
+    public required bool IsHardcore { get; set; }
+    public required string[] LevelNames { get; set; }
+    public required int MaxPlayers { get; set; }
+    public required int ViewDistance { get; set; }
+    public required int SimulationDistance { get; set; }
+    public required bool ReducedDebugInfo { get; set; }
+    public required bool ShowRespawnScreen { get; set; }
+    public required bool DoLimitedCrafting { get; set; }
+    public required int Dimension { get; set; }
+    public required DimensionInfo? DimensionInfo { get; set; }
+    public required long PartialHashedSeed { get; set; }
+    public required short Gamemode { get; set; }
+    public required short PreviousGamemode { get; set; }
+    public required KeyValuePair<string, long> LastDeathPosition { get; set; }
+    public required int PortalCooldown { get; set; }
+    public required int SeaLevel { get; set; }
+    public required bool OnlineMode { get; set; }
+    public required bool EnforcesSecureChat { get; set; }
+
+    public void Encode(ref MinecraftBuffer buffer, ProtocolVersion protocolVersion)
+    {
+        if (DimensionInfo is null)
+            throw new InvalidOperationException($"{nameof(DimensionInfo)} was not set.");
+
+        buffer.WriteInt(EntityId);
+        buffer.WriteBoolean(IsHardcore);
+
+        buffer.WriteVarInt(LevelNames.Length);
+        foreach (var levelName in LevelNames)
+            buffer.WriteString(levelName);
+
+        buffer.WriteVarInt(MaxPlayers);
+        buffer.WriteVarInt(ViewDistance);
+        buffer.WriteVarInt(SimulationDistance);
+
+        buffer.WriteBoolean(ReducedDebugInfo);
+        buffer.WriteBoolean(ShowRespawnScreen);
+        buffer.WriteBoolean(DoLimitedCrafting);
+
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_1_20_5)
+            buffer.WriteVarInt(Dimension);
+        else
+            buffer.WriteString(DimensionInfo.RegistryIdentifier);
+
+        buffer.WriteString(DimensionInfo.LevelName ?? string.Empty);
+        buffer.WriteLong(PartialHashedSeed);
+
+        buffer.WriteUnsignedByte(unchecked((byte)Gamemode));
+        buffer.WriteUnsignedByte(unchecked((byte)PreviousGamemode));
+
+        buffer.WriteBoolean(DimensionInfo.IsDebugType);
+        buffer.WriteBoolean(DimensionInfo.IsFlat);
+
+        if (LastDeathPosition.Key is null)
+        {
+            buffer.WriteBoolean(false);
+        }
+        else
+        {
+            buffer.WriteBoolean(true);
+            buffer.WriteString(LastDeathPosition.Key);
+            buffer.WriteLong(LastDeathPosition.Value);
+        }
+
+        buffer.WriteVarInt(PortalCooldown);
+
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_1_21_2)
+            buffer.WriteVarInt(SeaLevel);
+
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_26_2)
+            buffer.WriteBoolean(OnlineMode);
+
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_1_20_5)
+            buffer.WriteBoolean(EnforcesSecureChat);
+    }
+
+    public static JoinGamePacket Decode(ref MinecraftBuffer buffer, ProtocolVersion protocolVersion)
+    {
+        var entityId = buffer.ReadInt();
+        var isHardcore = buffer.ReadBoolean();
+
+        var levelNames = new string[buffer.ReadVarInt()];
+        for (var i = 0; i < levelNames.Length; i++)
+            levelNames[i] = buffer.ReadString();
+
+        var maxPlayers = buffer.ReadVarInt();
+        var viewDistance = buffer.ReadVarInt();
+        var simulationDistance = buffer.ReadVarInt();
+
+        var reducedDebugInfo = buffer.ReadBoolean();
+        var showRespawnScreen = buffer.ReadBoolean();
+        var doLimitedCrafting = buffer.ReadBoolean();
+
+        var dimension = default(int);
+        var dimensionIdentifier = string.Empty;
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_1_20_5)
+            dimension = buffer.ReadVarInt();
+        else
+            dimensionIdentifier = buffer.ReadString();
+
+        var levelName = buffer.ReadString();
+        var partialHashedSeed = buffer.ReadLong();
+
+        var gamemode = (short)(sbyte)buffer.ReadUnsignedByte();
+        var previousGamemode = (short)(sbyte)buffer.ReadUnsignedByte();
+
+        var isDebug = buffer.ReadBoolean();
+        var isFlat = buffer.ReadBoolean();
+        var dimensionInfo = new DimensionInfo(dimensionIdentifier, levelName, isFlat, isDebug);
+
+        var lastDeathPosition = default(KeyValuePair<string, long>);
+        if (buffer.ReadBoolean())
+            lastDeathPosition = new KeyValuePair<string, long>(buffer.ReadString(), buffer.ReadLong());
+
+        var portalCooldown = buffer.ReadVarInt();
+
+        var seaLevel = default(int);
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_1_21_2)
+            seaLevel = buffer.ReadVarInt();
+
+        var onlineMode = default(bool);
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_26_2)
+            onlineMode = buffer.ReadBoolean();
+
+        var enforcesSecureChat = default(bool);
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_1_20_5)
+            enforcesSecureChat = buffer.ReadBoolean();
+
+        return new JoinGamePacket
+        {
+            EntityId = entityId,
+            IsHardcore = isHardcore,
+            LevelNames = levelNames,
+            MaxPlayers = maxPlayers,
+            ViewDistance = viewDistance,
+            SimulationDistance = simulationDistance,
+            ReducedDebugInfo = reducedDebugInfo,
+            ShowRespawnScreen = showRespawnScreen,
+            DoLimitedCrafting = doLimitedCrafting,
+            Dimension = dimension,
+            DimensionInfo = dimensionInfo,
+            PartialHashedSeed = partialHashedSeed,
+            Gamemode = gamemode,
+            PreviousGamemode = previousGamemode,
+            LastDeathPosition = lastDeathPosition,
+            PortalCooldown = portalCooldown,
+            SeaLevel = seaLevel,
+            OnlineMode = onlineMode,
+            EnforcesSecureChat = enforcesSecureChat
+        };
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Clientbound/LoginSuccessPacket.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Packets/Clientbound/LoginSuccessPacket.cs
@@ -9,6 +9,7 @@ public class LoginSuccessPacket : IMinecraftClientboundPacket<LoginSuccessPacket
 {
     public required GameProfile GameProfile { get; set; }
     public required bool? StrictErrorHandling { get; set; }
+    public Uuid? SessionId { get; set; }
 
     public void Encode(ref MinecraftBuffer buffer, ProtocolVersion protocolVersion)
     {
@@ -17,12 +18,25 @@ public class LoginSuccessPacket : IMinecraftClientboundPacket<LoginSuccessPacket
         buffer.WritePropertyArray(GameProfile.Properties);
 
         if (protocolVersion < ProtocolVersion.MINECRAFT_1_20_5 || protocolVersion > ProtocolVersion.MINECRAFT_1_21)
+        {
+            if (protocolVersion < ProtocolVersion.MINECRAFT_26_2)
+                return;
+        }
+        else
+        {
+            if (!StrictErrorHandling.HasValue)
+                throw new InvalidDataException(nameof(StrictErrorHandling));
+
+            buffer.WriteBoolean(StrictErrorHandling.Value);
+        }
+
+        if (protocolVersion < ProtocolVersion.MINECRAFT_26_2)
             return;
 
-        if (!StrictErrorHandling.HasValue)
-            throw new InvalidDataException(nameof(StrictErrorHandling));
+        if (!SessionId.HasValue)
+            throw new InvalidDataException(nameof(SessionId));
 
-        buffer.WriteBoolean(StrictErrorHandling.Value);
+        buffer.WriteUuid(SessionId.Value);
     }
 
     public static LoginSuccessPacket Decode(ref MinecraftBuffer buffer, ProtocolVersion protocolVersion)
@@ -31,14 +45,19 @@ public class LoginSuccessPacket : IMinecraftClientboundPacket<LoginSuccessPacket
         var username = buffer.ReadString();
         var properties = buffer.ReadPropertyArray();
         bool? strictErrorHandling = null;
+        Uuid? sessionId = null;
 
         if (protocolVersion >= ProtocolVersion.MINECRAFT_1_20_5 && protocolVersion <= ProtocolVersion.MINECRAFT_1_21)
             strictErrorHandling = buffer.ReadBoolean();
 
+        if (protocolVersion >= ProtocolVersion.MINECRAFT_26_2)
+            sessionId = buffer.ReadUuid();
+
         return new LoginSuccessPacket
         {
             GameProfile = new GameProfile(username, uuid, properties),
-            StrictErrorHandling = strictErrorHandling
+            StrictErrorHandling = strictErrorHandling,
+            SessionId = sessionId
         };
     }
 

--- a/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Registries/Registry.cs
+++ b/src/Plugins/ProtocolSupport/Java/v1_20_2_to_latest/Registries/Registry.cs
@@ -36,6 +36,7 @@ public static class Registry
     {
         { PacketIdDefinitions.ClientboundBundleDelimiter, typeof(BundleDelimiterPacket) },
         { PacketIdDefinitions.ClientboundPlayKeepAliveRequest, typeof(KeepAliveRequestPacket) },
+        { PacketIdDefinitions.ClientboundJoinGame, typeof(JoinGamePacket) },
         { PacketIdDefinitions.ClientboundStartConfiguration, typeof(StartConfigurationPacket) },
         { PacketIdDefinitions.ClientboundPlayDisconnect, typeof(NbtDisconnectPacket) },
         { PacketIdDefinitions.ClientboundSystemChatMessage, typeof(SystemChatMessagePacket) },

--- a/tests/Void.UnitTests/Protocol/Minecraft26_2Tests.cs
+++ b/tests/Void.UnitTests/Protocol/Minecraft26_2Tests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Void.Minecraft.Buffers;
+using Void.Minecraft.Buffers.Extensions;
+using Void.Minecraft.Commands.Brigadier.Registry;
+using Void.Minecraft.Network;
+using Void.Minecraft.Network.Definitions;
+using Void.Minecraft.Profiles;
+using Void.Minecraft.World;
+using Xunit;
+using LatestJoinGamePacket = Void.Proxy.Plugins.ProtocolSupport.Java.v1_20_2_to_latest.Packets.Clientbound.JoinGamePacket;
+using LatestLoginSuccessPacket = Void.Proxy.Plugins.ProtocolSupport.Java.v1_20_2_to_latest.Packets.Clientbound.LoginSuccessPacket;
+
+namespace Void.UnitTests.Protocol;
+
+public class Minecraft26_2Tests
+{
+    [Fact]
+    public void ProtocolVersion_Registers26_2AsLatest()
+    {
+        Assert.Equal(776, ProtocolVersion.MINECRAFT_26_2.Value);
+        Assert.Equal("26.2", ProtocolVersion.MINECRAFT_26_2.ToString());
+        Assert.Same(ProtocolVersion.MINECRAFT_26_2, ProtocolVersion.Get(776));
+        Assert.Same(ProtocolVersion.MINECRAFT_26_2, ProtocolVersion.Latest);
+    }
+
+    [Fact]
+    public void LoginSuccess_26_2_RoundTripsSessionId()
+    {
+        var sessionId = Uuid.Parse("12345678-1234-5678-9abc-123456789abc");
+        var packet = new LatestLoginSuccessPacket
+        {
+            GameProfile = new GameProfile("Player", Uuid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), []),
+            StrictErrorHandling = null,
+            SessionId = sessionId
+        };
+
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        packet.Encode(ref buffer, ProtocolVersion.MINECRAFT_26_2);
+
+        stream.Position = 0;
+        var readBuffer = new MinecraftBuffer(stream);
+        var result = LatestLoginSuccessPacket.Decode(ref readBuffer, ProtocolVersion.MINECRAFT_26_2);
+
+        Assert.Equal(packet.GameProfile.Username, result.GameProfile.Username);
+        Assert.Equal(packet.GameProfile.Id, result.GameProfile.Id);
+        Assert.Empty(result.GameProfile.Properties ?? []);
+        Assert.Null(result.StrictErrorHandling);
+        Assert.Equal(sessionId, result.SessionId);
+    }
+
+    [Fact]
+    public void LoginSuccess_26_1_DoesNotWriteSessionId()
+    {
+        var packet = new LatestLoginSuccessPacket
+        {
+            GameProfile = new GameProfile("Player", Uuid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), []),
+            StrictErrorHandling = null,
+            SessionId = Uuid.Parse("12345678-1234-5678-9abc-123456789abc")
+        };
+
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        packet.Encode(ref buffer, ProtocolVersion.MINECRAFT_26_1);
+
+        stream.Position = 0;
+        var readBuffer = new MinecraftBuffer(stream);
+        var result = LatestLoginSuccessPacket.Decode(ref readBuffer, ProtocolVersion.MINECRAFT_26_1);
+
+        Assert.Null(result.SessionId);
+    }
+
+    [Fact]
+    public void ArgumentParserDefinitions_RenameColorToTeamColorIn26_2()
+    {
+        var color = ArgumentParserDefinitions.MinecraftArgumentParserDefinitions.Single(definition => definition.Mapping.Identifier == "minecraft:color").Mapping;
+        var teamColor = ArgumentParserDefinitions.MinecraftArgumentParserDefinitions.Single(definition => definition.Mapping.Identifier == "minecraft:team_color").Mapping;
+
+        Assert.True(color.TryGetParserId(ProtocolVersion.MINECRAFT_26_1, out var colorId));
+        Assert.Equal(16, colorId);
+        Assert.False(color.TryGetParserId(ProtocolVersion.MINECRAFT_26_2, out _));
+        Assert.True(teamColor.TryGetParserId(ProtocolVersion.MINECRAFT_26_2, out var teamColorId));
+        Assert.Equal(16, teamColorId);
+    }
+
+    [Fact]
+    public void ArgumentSerializerRegistry_DecodesParserId16AsTeamColorIn26_2()
+    {
+        Span<byte> data = stackalloc byte[5];
+        var buffer = new BufferSpan(data);
+        buffer.WriteVarInt(16);
+        buffer.Position = 0;
+
+        var mapping = ArgumentSerializerRegistry.DecodeParserMapping(ref buffer, ProtocolVersion.MINECRAFT_26_2);
+
+        Assert.Equal("minecraft:team_color", mapping.Identifier);
+    }
+
+    [Fact]
+    public void JoinGame_26_2_RoundTripsOnlineModeBeforeSecureChat()
+    {
+        var packet = new LatestJoinGamePacket
+        {
+            EntityId = 42,
+            IsHardcore = true,
+            LevelNames = ["minecraft:overworld", "minecraft:the_nether"],
+            MaxPlayers = 20,
+            ViewDistance = 12,
+            SimulationDistance = 8,
+            ReducedDebugInfo = true,
+            ShowRespawnScreen = false,
+            DoLimitedCrafting = true,
+            Dimension = 1,
+            DimensionInfo = new DimensionInfo("minecraft:overworld", "minecraft:overworld", IsFlat: false, IsDebugType: true),
+            PartialHashedSeed = 123456789L,
+            Gamemode = 1,
+            PreviousGamemode = -1,
+            LastDeathPosition = new KeyValuePair<string, long>("minecraft:overworld", 12345L),
+            PortalCooldown = 80,
+            SeaLevel = 63,
+            OnlineMode = true,
+            EnforcesSecureChat = false
+        };
+
+        using var stream = new MemoryStream();
+        var buffer = new MinecraftBuffer(stream);
+        packet.Encode(ref buffer, ProtocolVersion.MINECRAFT_26_2);
+
+        stream.Position = 0;
+        var readBuffer = new MinecraftBuffer(stream);
+        var result = LatestJoinGamePacket.Decode(ref readBuffer, ProtocolVersion.MINECRAFT_26_2);
+
+        Assert.Equal(packet.EntityId, result.EntityId);
+        Assert.Equal(packet.LevelNames, result.LevelNames);
+        Assert.Equal(packet.Dimension, result.Dimension);
+        Assert.Equal(packet.DimensionInfo.LevelName, result.DimensionInfo?.LevelName);
+        Assert.Equal(packet.PreviousGamemode, result.PreviousGamemode);
+        Assert.Equal(packet.LastDeathPosition, result.LastDeathPosition);
+        Assert.Equal(packet.SeaLevel, result.SeaLevel);
+        Assert.True(result.OnlineMode);
+        Assert.False(result.EnforcesSecureChat);
+        Assert.False(readBuffer.HasData);
+    }
+
+    [Fact]
+    public void PacketIdDefinitions_MapLatestJoinGamePacketIds()
+    {
+        Assert.Contains(PacketIdDefinitions.ClientboundJoinGame, mapping => mapping.ProtocolVersion == ProtocolVersion.MINECRAFT_1_20_2 && mapping.Id == 0x29);
+        Assert.Contains(PacketIdDefinitions.ClientboundJoinGame, mapping => mapping.ProtocolVersion == ProtocolVersion.MINECRAFT_1_20_5 && mapping.Id == 0x2B);
+        Assert.Contains(PacketIdDefinitions.ClientboundJoinGame, mapping => mapping.ProtocolVersion == ProtocolVersion.MINECRAFT_1_21_2 && mapping.Id == 0x2C);
+        Assert.Contains(PacketIdDefinitions.ClientboundJoinGame, mapping => mapping.ProtocolVersion == ProtocolVersion.MINECRAFT_1_21_5 && mapping.Id == 0x2B);
+        Assert.Contains(PacketIdDefinitions.ClientboundJoinGame, mapping => mapping.ProtocolVersion == ProtocolVersion.MINECRAFT_1_21_9 && mapping.Id == 0x30);
+        Assert.Contains(PacketIdDefinitions.ClientboundJoinGame, mapping => mapping.ProtocolVersion == ProtocolVersion.MINECRAFT_26_1 && mapping.Id == 0x31);
+    }
+}

--- a/tests/Void.UnitTests/Void.UnitTests.csproj
+++ b/tests/Void.UnitTests/Void.UnitTests.csproj
@@ -23,6 +23,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Plugins\Common\Void.Proxy.Plugins.Common.csproj" />
+	  <ProjectReference Include="..\..\src\Plugins\ProtocolSupport\Java\v1_20_2_to_latest\Void.Proxy.Plugins.ProtocolSupport.Java.v1_20_2_to_latest.csproj" />
 	  <ProjectReference Include="..\..\src\Platform\Void.Proxy.csproj" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Added Minecraft 26.2 / protocol 776 support and updated affected latest-protocol login, join-game, and brigadier behavior.

## Rationale
Velocity added 26.2 support in [**PaperMC/Velocity d7ad052**](https://github.com/PaperMC/Velocity/commit/d7ad0522e9a7e4874049ffa8ebd40176db61805e). Void needs matching protocol awareness so 26.2 clients can complete login and parse latest command argument IDs.

The checked protocol page revision was [**Java Edition protocol/Packets oldid 3640366**](https://minecraft.wiki/w/Java_Edition_protocol/Packets?oldid=3640366). That revision currently lists Join Game fields including "Sea level" followed by "Enforces Secure Chat"; the requested Velocity commit supplies the 26.2 delta by inserting the online-mode boolean between those fields.

## Changes
- Registered `ProtocolVersion.MINECRAFT_26_2` as protocol 776.
- Added 26.2 Login Success session UUID serialization and generated a random session UUID for 26.2+ proxy login completion.
- Added latest-family Join Game packet serialization for 1.20.2+ and the 26.2 online-mode boolean.
- Updated brigadier parser mappings so `minecraft:color` is removed at 26.2 and `minecraft:team_color` takes parser ID 16.
- Added unit coverage for protocol registration, Login Success, Join Game, brigadier mappings, and latest Join Game packet IDs.

## Verification
- `dotnet test tests/Void.UnitTests/ -p:UseSharedCompilation=false`
- `dotnet test tests/Void.UnitTests/ --no-restore -m:1`
- `dotnet build -m:1`

The plain `dotnet test tests/Void.UnitTests/` command hit intermittent `csc` exit code 132 in different projects; disabling shared compilation or running single-node completed successfully.

## Performance
No measured performance impact. Changes are version-gated packet field reads/writes and static mapping additions.

## Risks & Rollback
Risk is limited to latest protocol packet serialization and command argument mapping. Roll back by reverting this commit if 26.2 wire details change upstream.

## Breaking/Migration
No user migration required.

## Links
- [**Velocity 26.2 commit**](https://github.com/PaperMC/Velocity/commit/d7ad0522e9a7e4874049ffa8ebd40176db61805e)
- [**Minecraft 26.2 release notes**](https://www.minecraft.net/en-us/article/minecraft-java-edition-26-2)
- [**Protocol packet revision checked**](https://minecraft.wiki/w/Java_Edition_protocol/Packets?oldid=3640366)
